### PR TITLE
Sixteen.patch added for 5.16.x support

### DIFF
--- a/nvidia-merged/PKGBUILD
+++ b/nvidia-merged/PKGBUILD
@@ -12,7 +12,7 @@ options=('!strip')
 groups=('nvidia-merged')
 _pkg="NVIDIA-Linux-${CARCH}-${pkgver}-grid-vgpu-kvm-v5"
 _vgpuver=460.73.02
-source=('nvidia-drm-outputclass.conf' 'nvidia-smi' 'nvidia-vgpu.conf' 'vgpu_unlock-rs.conf' 'twelve.patch' 'fourteen.patch' '99-nvidia-ignoreabi.conf'
+source=('nvidia-drm-outputclass.conf' 'nvidia-smi' 'nvidia-vgpu.conf' 'vgpu_unlock-rs.conf' 'twelve.patch' 'fourteen.patch' 'sixteen.patch' '99-nvidia-ignoreabi.conf'
     "${_pkg}.run::gdrive://1dCyUteA2MqJaemRKqqTu5oed5mINu9Bw"
     'git+https://github.com/mbilker/vgpu_unlock-rs.git#commit=6541af7')
 sha256sums=('be99ff3def641bb900c2486cce96530394c5dc60548fc4642f19d3a4c784134d'
@@ -21,6 +21,7 @@ sha256sums=('be99ff3def641bb900c2486cce96530394c5dc60548fc4642f19d3a4c784134d'
             'c85ae100a6c87c12906fd0057b77c0c4190f68434de4bc3bc89348ffc19aed61'
             '8c374e9e6053c20b0bcf71faf33adfa2659c1020ce1f38d469b42dd2bbda9749'
             'affb0b2fde720ee7963746bc7a4eda459b1dd1a8a5650b4ae2de64c9e6cf54f1'
+            'fafcd708e1b0013969ddaaf945ed9ab1878d3e40c00780e77f23f2e7b32f0962'
             'a5caf3ce59fea2f99643be73412224cf27846bc10f09ba3a4758b05bbbf5fb1d'
             '0bc28cf13c1a4d8845c7f8987974e04bd52734321bb8db526c6938530ad12c71'
             'SKIP')
@@ -59,6 +60,7 @@ prepare() {
 
     cp "${srcdir}/twelve.patch" patches/
     cp "${srcdir}/fourteen.patch" patches/
+    cp "${srcdir}/sixteen.patch" patches/
 
     patch -R -p1 < patches/twelve.patch
 
@@ -77,9 +79,11 @@ BUILT_MODULE_NAME[4]="nvidia-vgpu-vfio"\
 DEST_MODULE_LOCATION[4]="/kernel/drivers/video"\
 \
 PATCH[0]="twelve.patch"\
-PATCH_MATCH[0]="^5.1[012345].*$"\
+PATCH_MATCH[0]="^5.1[0123456].*$"\
 PATCH[1]="fourteen.patch"\
-PATCH_MATCH[1]="^5\.1[45].*$"' dkms.conf
+PATCH_MATCH[1]="^5\.1[456].*$"\
+PATCH[2]="sixteen.patch"\
+PATCH_MATCH[2]="^5\.16.*$' dkms.conf
 }
 
 build() {

--- a/nvidia-merged/PKGBUILD
+++ b/nvidia-merged/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase='nvidia-merged'
 pkgname=('nvidia-merged' 'lib32-nvidia-merged-utils' 'lib32-opencl-nvidia-merged' 'nvidia-merged-dkms' 'nvidia-merged-settings' 'nvidia-merged-utils' 'opencl-nvidia-merged')
 pkgver=460.73.01
-pkgrel=16
+pkgrel=17
 arch=('x86_64')
 makedepends=('git' 'rust')
 url='https://krutavshah.github.io/GPU_Virtualization-Wiki/'

--- a/nvidia-merged/PKGBUILD
+++ b/nvidia-merged/PKGBUILD
@@ -83,7 +83,7 @@ PATCH_MATCH[0]="^5.1[0123456].*$"\
 PATCH[1]="fourteen.patch"\
 PATCH_MATCH[1]="^5\.1[456].*$"\
 PATCH[2]="sixteen.patch"\
-PATCH_MATCH[2]="^5\.16.*$' dkms.conf
+PATCH_MATCH[2]="^5\.16.*$"' dkms.conf
 }
 
 build() {

--- a/nvidia-merged/sixteen.patch
+++ b/nvidia-merged/sixteen.patch
@@ -1,0 +1,93 @@
+diff --git a/common/inc/nv-misc.h b/common/inc/nv-misc.h
+index cd5ffb9..9e0bf38 100644
+--- a/common/inc/nv-misc.h
++++ b/common/inc/nv-misc.h
+@@ -17,7 +17,7 @@
+ #if defined(NV_KERNEL_INTERFACE_LAYER) && defined(__FreeBSD__)
+   #include <sys/stddef.h> // NULL
+ #else
+-  #include <stddef.h>     // NULL
++  #include <linux/stddef.h>     // NULL
+ #endif
+ 
+ #endif /* _NV_MISC_H_ */
+diff --git a/common/inc/nv.h b/common/inc/nv.h
+index d56e97d..fcd2d2d 100644
+--- a/common/inc/nv.h
++++ b/common/inc/nv.h
+@@ -22,7 +22,7 @@
+ 
+ #include <nvtypes.h>
+ #include <nvCpuUuid.h>
+-#include <stdarg.h>
++#include <linux/stdarg.h>
+ #include <nv-caps.h>
+ #include <nv-ioctl.h>
+ #include <nvmisc.h>
+diff --git a/common/inc/os-interface.h b/common/inc/os-interface.h
+index 4d7383b..398fdc8 100644
+--- a/common/inc/os-interface.h
++++ b/common/inc/os-interface.h
+@@ -24,7 +24,7 @@
+ *                                                                           *
+ \***************************************************************************/
+ 
+-#include <stdarg.h>
++#include <linux/stdarg.h>
+ #include <nv-kernel-interface-api.h>
+ #include <os/nv_memory_type.h>
+ 
+diff --git a/nvidia-modeset/nvidia-modeset-os-interface.h b/nvidia-modeset/nvidia-modeset-os-interface.h
+index 6e6bfcb..21b5635 100644
+--- a/nvidia-modeset/nvidia-modeset-os-interface.h
++++ b/nvidia-modeset/nvidia-modeset-os-interface.h
+@@ -16,8 +16,8 @@
+ #if !defined(_NVIDIA_MODESET_OS_INTERFACE_H_)
+ #define _NVIDIA_MODESET_OS_INTERFACE_H_
+ 
+-#include <stddef.h>  /* size_t */
+-#include <stdarg.h>  /* va_list */
++#include <linux/stddef.h>  /* size_t */
++#include <linux/stdarg.h>  /* va_list */
+ 
+ #include "nvtypes.h" /* NvU8 */
+ 
+diff --git a/nvidia-modeset/nvkms.h b/nvidia-modeset/nvkms.h
+index ff49fdf..aa368a0 100644
+--- a/nvidia-modeset/nvkms.h
++++ b/nvidia-modeset/nvkms.h
+@@ -9,7 +9,7 @@
+ #define __NV_KMS_H__
+ 
+ #include "nvtypes.h"
+-#include <stddef.h> /* size_t */
++#include <linux/stddef.h> /* size_t */
+ 
+ #include "nvkms-kapi.h"
+ 
+diff --git a/nvidia-uvm/uvm_mmu.c b/nvidia-uvm/uvm_mmu.c
+index d7351f0..fcd54bf 100644
+--- a/nvidia-uvm/uvm_mmu.c
++++ b/nvidia-uvm/uvm_mmu.c
+@@ -32,7 +32,7 @@
+ #include "uvm_push.h"
+ #include "uvm_mem.h"
+ #include "uvm_va_space.h"
+-#include <stdarg.h>
++#include <linux/stdarg.h>
+ 
+ // The page tree has 5 levels on pascal, and the root is never freed by a normal 'put' operation
+ // which leaves a maximum of 4 levels
+diff --git a/nvidia/export_nvswitch.h b/nvidia/export_nvswitch.h
+index 8902fa0..253e272 100644
+--- a/nvidia/export_nvswitch.h
++++ b/nvidia/export_nvswitch.h
+@@ -28,7 +28,7 @@
+ extern "C" {
+ #endif
+ 
+-#include <stdarg.h>
++#include <linux/stdarg.h>
+ #include "nvlink_common.h"
+ #include "ioctl_common_nvswitch.h"
+ 


### PR DESCRIPTION
Added rezzafr33's patch from the libvf.io discord to support 5.16.x kernels. tested on 5.16.2-arch1-1

note: The pkgrel on the PKGBUILD in the repo is 15 but on the AUR's version of the PKGBUILD it is 16 so i have followed on from the AUR but the changes should work regardless of the pkgrel. if this isnt correct then feel free to change it