### PR TITLE
Add 'nvidia' to conflicting packages

### DIFF
--- a/nvidia-merged/.SRCINFO
+++ b/nvidia-merged/.SRCINFO
@@ -66,6 +66,7 @@ pkgname = nvidia-merged-dkms
 	provides = NVIDIA-MODULE
 	provides = nvidia-dkms
 	conflicts = nvidia-dkms
+	conflicts = nvidia
 
 pkgname = nvidia-merged-settings
 	pkgdesc = Tool for configuring the NVIDIA graphics driver

--- a/nvidia-merged/PKGBUILD
+++ b/nvidia-merged/PKGBUILD
@@ -142,7 +142,7 @@ package_nvidia-merged-dkms() {
     pkgdesc="NVIDIA drivers - module sources; patched for vGPU support w/ Rust unlock & host DRM output"
     depends=('dkms' "nvidia-merged-utils=${pkgver}" 'libglvnd')
     provides=('NVIDIA-MODULE' 'nvidia-dkms')
-    conflicts=('nvidia-dkms')
+    conflicts=('nvidia-dkms' 'nvidia')
 
     install -d -m755 "${pkgdir}/usr/src"
     cp -dr --no-preserve='ownership' "${_gridpkg}/kernel" "${pkgdir}/usr/src/nvidia-${_gridpkgver}"


### PR DESCRIPTION
[Arch's `nvidia-dkms`](https://archlinux.org/packages/extra/x86_64/nvidia-dkms/) package marks `nvidia` as conflicting.
As your package `nvidia-merged-dkms` acts as a drop-in replacement for `nvidia-dkms`, we may want to mark `nvidia` as conflicting too.

I can also add this conflict in your other package `nvidia-vgpu-dkms` if you wish.