### PR TITLE
Update vGPU unlock dependency to 2.3.1

### DIFF
--- a/nvidia-merged/.SRCINFO
+++ b/nvidia-merged/.SRCINFO
@@ -20,7 +20,7 @@ pkgbase = nvidia-merged
 	source = vgpu_unlock.patch
 	source = file://NVIDIA-Linux-x86_64-510.73.08-grid.run
 	source = file://NVIDIA-Linux-x86_64-510.73.06-vgpu-kvm.run
-	source = git+https://github.com/mbilker/vgpu_unlock-rs.git#commit=6deede6
+	source = git+https://github.com/mbilker/vgpu_unlock-rs.git#commit=aa56da6
 	sha256sums = be99ff3def641bb900c2486cce96530394c5dc60548fc4642f19d3a4c784134d
 	sha256sums = 20676096714ac00d9fc993901ab275e4b0fa3f2eddc937dae395c8f4e8cb543e
 	sha256sums = 5ea0d9edfcf282cea9b204291716a9a4d6d522ba3a6bc28d78edf505b6dc7949

--- a/nvidia-merged/PKGBUILD
+++ b/nvidia-merged/PKGBUILD
@@ -42,7 +42,7 @@ source=(
     'vgpu_unlock.patch'
     "file://${_gridpkg}.run"
     "file://${_vgpupkg}.run"
-    'git+https://github.com/mbilker/vgpu_unlock-rs.git#commit=6deede6')
+    'git+https://github.com/mbilker/vgpu_unlock-rs.git#commit=aa56da6')
 sha256sums=('be99ff3def641bb900c2486cce96530394c5dc60548fc4642f19d3a4c784134d'
             '20676096714ac00d9fc993901ab275e4b0fa3f2eddc937dae395c8f4e8cb543e'
             '5ea0d9edfcf282cea9b204291716a9a4d6d522ba3a6bc28d78edf505b6dc7949'


### PR DESCRIPTION
Use latest version of [vGPU unlock tool](https://github.com/mbilker/vgpu_unlock-rs), which add one or two fixes plus compatibility improvement with latest Rust compiler version.

I can also add this update in your other package `nvidia-vgpu-dkms` if you wish.